### PR TITLE
Chore/fix e2es

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /test-results/
+/playwright
 /playwright-report/
 /playwright/.cache/
-/playwright/.auth/
 /.env
+/.DS_Store

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "npx playwright test",
+    "test:ui": "npx playwright test --ui",
+    "install-playwright": "npx playwright install"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e.git"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,77 +1,25 @@
-import { defineConfig, devices } from '@playwright/test';
+import 'dotenv/config'
+import { defineConfig, devices } from '@playwright/test'
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
   testDir: './tests',
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  maxFailures: 1,
+  workers: 1,
   reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://supported-accommodation-dev.hmpps.service.justice.gov.uk',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    baseURL: 'https://community-accommodation-tier-2-dev.hmpps.service.justice.gov.uk/',
     trace: 'on-first-retry',
+    video: 'on-first-retry',
   },
-
-  /* Configure projects for major browsers */
   projects: [
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'], storageState: 'playwright/.auth/user.json' },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Chrome'], storageState: 'playwright/.auth/user.json' },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Chrome'], storageState: 'playwright/.auth/user.json' },
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
-});
+})

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('has a title and a list of accredited programmes', async ({ page }) => {
-  await page.goto('https://accredited-programmes-dev.hmpps.service.justice.gov.uk/programmes')
+test('has a title', async ({ page }) => {
+  await page.goto('/')
 
-  await expect(page.locator('h1')).toHaveText("List of accredited programmes");
-  await expect(page.locator('div[role="listitem"] a')).toHaveText(['Thinking Skills Programme', 'Becoming new me +', 'New me strengths']);
+  await expect(page.locator('h1')).toHaveText("Apply for a CAS-2 placement");
 });


### PR DESCRIPTION
Our tests were failing because they were not able to find the auth storage file (`playwright/.auth/user.json`) - this should be fixed now and tests should be able to run locally following these steps:

`npm run install-playwright`
`npm run test`

This PR:
* fixes the Playwright config: Previously the `setup` job was not being run to add the auth file in
storage. The other projects need to depend on the `setup`. [1]

[1] https://playwright.dev/docs/auth
* adds a basic smoke test for the title of the service