### PR TITLE
Add test for funding information application page

### DIFF
--- a/pages/apply/applyPage.ts
+++ b/pages/apply/applyPage.ts
@@ -1,0 +1,11 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class ApplyPage extends BasePage {
+  static async initialize(page: Page, title?: string) {
+    if (title) {
+      await expect(page.locator('h1')).toContainText(title)
+    }
+    return new ApplyPage(page)
+  }
+}

--- a/pages/apply/crnPage.ts
+++ b/pages/apply/crnPage.ts
@@ -1,0 +1,7 @@
+import { BasePage } from '../basePage'
+
+export class CRNPage extends BasePage {
+  async enterCrn(crn: string) {
+    await this.page.getByLabel("Enter the person's CRN").fill(crn)
+  }
+}

--- a/pages/apply/index.ts
+++ b/pages/apply/index.ts
@@ -1,0 +1,5 @@
+import { CRNPage } from './crnPage'
+import { TaskListPage } from './taskListPage'
+import { ApplyPage } from './applyPage'
+
+export { CRNPage, TaskListPage, ApplyPage }

--- a/pages/apply/taskListPage.ts
+++ b/pages/apply/taskListPage.ts
@@ -1,0 +1,7 @@
+import { BasePage } from '../basePage'
+
+export class TaskListPage extends BasePage {
+  async clickTask(taskName: string) {
+    await this.page.getByRole('link', { name: taskName }).click()
+  }
+}

--- a/pages/basePage.ts
+++ b/pages/basePage.ts
@@ -1,0 +1,48 @@
+import { Page } from '@playwright/test'
+
+export class BasePage {
+  constructor(public readonly page: Page) {}
+
+  async clickSave() {
+    await this.page.getByRole('button', { name: 'Save and continue' }).click()
+  }
+
+  async clickSubmit() {
+    await this.page.getByRole('button', { name: 'Submit' }).click()
+  }
+
+  async clickContinue() {
+    await this.page.getByRole('button', { name: 'Continue' }).click()
+  }
+
+  async fillField(label: string, value: string) {
+    await this.page.getByLabel(label).fill(value)
+  }
+
+  async checkRadio(label: string) {
+    await this.page.getByLabel(label, { exact: true }).check()
+  }
+
+  async checkRadioInGroup(group: string, label: string) {
+    await this.page
+      .getByRole('group', {
+        name: group,
+      })
+      .getByLabel(label, { exact: true })
+      .check()
+  }
+
+  async checkCheckboxes(labels: Array<string>) {
+    const promises = [] as Array<Promise<void>>
+
+    labels.forEach(label => promises.push(this.page.getByLabel(label).dispatchEvent('click')))
+
+    await Promise.all(promises)
+  }
+
+  async fillDateField({ year, month, day }: { year: string; month: string; day: string }) {
+    await this.page.getByLabel('Day', { exact: true }).fill(day)
+    await this.page.getByLabel('Month', { exact: true }).fill(month)
+    await this.page.getByLabel('Year', { exact: true }).fill(year)
+  }
+}

--- a/pages/dashboardPage.ts
+++ b/pages/dashboardPage.ts
@@ -1,0 +1,11 @@
+import { BasePage } from './basePage'
+
+export class DashboardPage extends BasePage {
+  async goto() {
+    await this.page.goto('/')
+  }
+
+  async clickStartApplication() {
+    await this.page.getByRole('button', { name: 'Start now' }).click()
+  }
+}

--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -1,0 +1,27 @@
+import { Page } from '@playwright/test'
+import { DashboardPage } from '../pages/dashboardPage'
+import { ApplyPage, CRNPage, TaskListPage } from '../pages/apply'
+
+export const visitDashboard = async (page: Page): Promise<DashboardPage> => {
+  const dashboard = new DashboardPage(page)
+  await dashboard.goto()
+
+  return dashboard
+}
+
+export const enterCrn = async (dashboard: DashboardPage, page: Page, crn: string) => {
+  await dashboard.clickStartApplication()
+
+  const crnPage = new CRNPage(page)
+  await crnPage.enterCrn(crn)
+  await crnPage.clickSave()
+}
+
+export const completeFundingInformationTask = async (page: Page) => {
+  const taskListPage = new TaskListPage(page)
+  await taskListPage.clickTask('Funding information')
+
+  const fundingInformationPage = await ApplyPage.initialize(page, 'Funding information')
+  await fundingInformationPage.checkRadio('Personal money or savings')
+  await fundingInformationPage.clickSave()
+}

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -1,0 +1,10 @@
+import { test } from '../test'
+import { completeFundingInformationTask, enterCrn, visitDashboard } from '../steps/apply'
+
+test('create a CAS-2 application with funding information', async ({ page, person }) => {
+  const dashboard = await visitDashboard(page)
+
+  await enterCrn(dashboard, page, person.crn)
+
+  await completeFundingInformationTask(page)
+})

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,7 +1,0 @@
-import { expect, test } from '@playwright/test'
-
-test('has a title', async ({ page }) => {
-  await page.goto('/')
-
-  await expect(page.locator('h1')).toHaveText('Apply for a CAS-2 placement')
-})


### PR DESCRIPTION
This commit tailors for our purposes several page classes used by CAS1 in their E2E tests.

I have also included a number of methods on the BasePage class that we are not currently using, but are likely to use in the future.