### PR TITLE
Fix E2E tests for separate 'Find by CRN' form

### DIFF
--- a/pages/apply/applicationsDashboardPage.ts
+++ b/pages/apply/applicationsDashboardPage.ts
@@ -1,0 +1,7 @@
+import { BasePage } from '../basePage'
+
+export class ApplicationsDashboardPage extends BasePage {
+  async startNewApplication() {
+    await this.page.getByRole('link', { name: 'Start a new application' }).click()
+  }
+}

--- a/pages/apply/index.ts
+++ b/pages/apply/index.ts
@@ -1,5 +1,7 @@
 import { CRNPage } from './crnPage'
 import { TaskListPage } from './taskListPage'
 import { ApplyPage } from './applyPage'
+import { StartPage } from './startPage'
+import { ApplicationsDashboardPage } from './applicationsDashboardPage'
 
-export { CRNPage, TaskListPage, ApplyPage }
+export { CRNPage, TaskListPage, ApplyPage, StartPage, ApplicationsDashboardPage }

--- a/pages/apply/startPage.ts
+++ b/pages/apply/startPage.ts
@@ -1,11 +1,11 @@
-import { BasePage } from './basePage'
+import { BasePage } from '../basePage'
 
-export class DashboardPage extends BasePage {
+export class StartPage extends BasePage {
   async goto() {
     await this.page.goto('/')
   }
 
-  async clickStartApplication() {
+  async startNow() {
     await this.page.getByRole('button', { name: 'Start now' }).click()
   }
 }

--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -1,17 +1,24 @@
 import { Page } from '@playwright/test'
-import { DashboardPage } from '../pages/dashboardPage'
-import { ApplyPage, CRNPage, TaskListPage } from '../pages/apply'
+import { ApplicationsDashboardPage, ApplyPage, CRNPage, StartPage, TaskListPage } from '../pages/apply'
 
-export const visitDashboard = async (page: Page): Promise<DashboardPage> => {
-  const dashboard = new DashboardPage(page)
-  await dashboard.goto()
+export const startAnApplication = async (page: Page) => {
+  // Start page
+  // --------
+  // visit the root url
+  const startPage = new StartPage(page)
+  await startPage.goto()
 
-  return dashboard
+  // // confirm that I'm ready to start
+  await startPage.startNow()
+
+  // Applications dashboard
+  // -----------------
+  // Follow link to 'Start a new application'
+  const applicationsDashboard = new ApplicationsDashboardPage(page)
+  await applicationsDashboard.startNewApplication()
 }
 
-export const enterCrn = async (dashboard: DashboardPage, page: Page, crn: string) => {
-  await dashboard.clickStartApplication()
-
+export const enterCrn = async (page: Page, crn: string) => {
   const crnPage = new CRNPage(page)
   await crnPage.enterCrn(crn)
   await crnPage.clickSave()

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -1,10 +1,10 @@
 import { test } from '../test'
-import { completeFundingInformationTask, enterCrn, visitDashboard } from '../steps/apply'
+import { completeFundingInformationTask, enterCrn, startAnApplication } from '../steps/apply'
 
 test('create a CAS-2 application with funding information', async ({ page, person }) => {
-  const dashboard = await visitDashboard(page)
+  await startAnApplication(page)
 
-  await enterCrn(dashboard, page, person.crn)
+  await enterCrn(page, person.crn)
 
   await completeFundingInformationTask(page, person.name)
 })


### PR DESCRIPTION
The 'apply' journey test was broken due to the introduction of a separate page for the "Enter a CRN" form.

I've taken the opportunity to try to make the tests clearer by renaming some helper "page" classes and other
refactorings:

STRUCTURE OF 'APPLY' FEATURE

- `startAnApplication(page)` navigate to the start of the journey

- `enterCrn(page, person.crn)` search for a person

- `completeFundingInformationTask(page, person.name)`: complete a task

we'll shortly add another "completeTask" step:

- `completeEqualityAndDiversityTask(page, person.name)`

"PAGE" HELPER NAMES

- `StartPage` is used to navigate to and from the  homepage / root url

- `ApplicationsDashboardPage` is the 'index' or list of applications, which we anticipate developing into an important 'dashboard'