### PR TITLE
update `@playwright/test` to 1.36.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.34.1",
+        "@playwright/test": "^1.36.2",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "date-fns": "^2.30.0",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e#readme",
   "dependencies": {
-    "@playwright/test": "^1.34.1",
+    "@playwright/test": "^1.36.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "date-fns": "^2.30.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
It looks like the e2e tests are failing on CI, possibly because this hasn't been updated? https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-community-accommodation-tier-2-ui/625/workflows/927e0f8c-c9a9-4990-b386-83967663e5f9/jobs/1665/parallel-runs/0/steps/0-108 