### PR TITLE
Update Playwright to v 1.36.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.34.1",
+        "@playwright/test": "^1.36.2",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "date-fns": "^2.30.0",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-e2e#readme",
   "dependencies": {
-    "@playwright/test": "^1.34.1",
+    "@playwright/test": "^1.36.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "date-fns": "^2.30.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
We're seeing an error in CI:
```
1) [setupDev] › auth.setup.ts:5:6 › authenticate

    Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1071/chrome-linux/chrome

    ║ Looks like Playwright Test or Playwright was just updated to 1.36.2. ║
    ║ Please update docker image as well.                                  ║
    ║ -  current: mcr.microsoft.com/playwright:v1.34.1-focal               ║
    ║ - required: mcr.microsoft.com/playwright:v1.36.2-focal               ║
    ║                                                                      ║
    ║ <3 Playwright Team                                                   ║
 ```