### PR TITLE
Add 'Health needs' task within 'Risks and needs' section

### DIFF
--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test'
 import { ApplicationsDashboardPage, CRNPage, StartPage } from '../pages/apply'
 import { completeEligibilityTask } from './beforeYouStartSection'
 import { completeEqualityAndDiversityTask } from './aboutThePersonSection'
+import { completeHealthNeedsTask } from './risksAndNeedsSection'
 import { completeFundingInformationTask } from './areaAndFundingSection'
 
 export const startAnApplication = async (page: Page) => {
@@ -37,4 +38,8 @@ export const completeAreaAndFundingSection = async (page: Page, name: string) =>
 
 export const completeAboutThePersonSection = async (page: Page, name: string) => {
   await completeEqualityAndDiversityTask(page, name)
+}
+
+export const completeRisksAndNeedsSection = async (page: Page, name: string) => {
+  await completeHealthNeedsTask(page, name)
 }

--- a/steps/risksAndNeedsSection.ts
+++ b/steps/risksAndNeedsSection.ts
@@ -1,0 +1,103 @@
+import { Page } from '@playwright/test'
+import { ApplyPage, TaskListPage } from '../pages/apply'
+
+export const completeHealthNeedsTask = async (page: Page, name: string) => {
+  const taskListPage = new TaskListPage(page)
+  await taskListPage.clickTask('Add health needs')
+
+  await reviewGuidancePage(page, name)
+  await completeSubstanceMisusePage(page, name)
+  await completePhysicalHealthPage(page, name)
+  await completeMentalHealthPage(page, name)
+  await completeCommunicationAndLanguagePage(page, name)
+  await completeLearningDifficultiesPage(page, name)
+  await completeBrainInjuryPage(page, name)
+  await completeOtherHealthPage(page, name)
+}
+
+async function reviewGuidancePage(page: Page, name) {
+  const guidancePage = await ApplyPage.initialize(page, `Request health information for ${name}`)
+  await guidancePage.clickSave()
+}
+
+async function completeSubstanceMisusePage(page: Page, name) {
+  const substanceMisusePage = await ApplyPage.initialize(page, `Health needs for ${name}`)
+
+  await substanceMisusePage.checkRadioInGroup('take any illegal substances', 'No')
+  await substanceMisusePage.checkRadioInGroup('drug and alcohol service', 'No')
+  await substanceMisusePage.checkRadioInGroup('substitute medication', 'No')
+
+  await substanceMisusePage.clickSave()
+}
+
+async function completePhysicalHealthPage(page: Page, name) {
+  const physicalHealthPage = await ApplyPage.initialize(page, `Physical health needs for ${name}`)
+
+  // we can't use the normal checkRadioInGroup() helper due to follow-on yes/no radios
+  // triggering Error: strict mode violation
+  await page.getByRole('group', { name: 'Do they have any physical health needs?' }).locator('label').nth(4).click()
+  await physicalHealthPage.checkRadioInGroup('receiving any medical treatment', 'No')
+  await physicalHealthPage.checkRadioInGroup('receiving any medication', 'No')
+  await physicalHealthPage.checkRadioInGroup('live independently', 'Yes')
+  await physicalHealthPage.checkRadioInGroup('additional support', 'No')
+
+  await physicalHealthPage.clickSave()
+}
+
+async function completeMentalHealthPage(page: Page, name) {
+  const mentalHealthPage = await ApplyPage.initialize(page, `Mental health needs for ${name}`)
+
+  await mentalHealthPage.checkRadioInGroup('any mental health needs', 'No')
+  await mentalHealthPage.checkRadioInGroup('community mental health services', 'No')
+
+  // we can't use the normal checkRadioInGroup() helper due to follow-on yes/no radios
+  // triggering Error: strict mode violation
+  await page.locator('css=input[name="hasPrescribedMedication"][value="no"]').click()
+
+  await mentalHealthPage.clickSave()
+}
+
+async function completeCommunicationAndLanguagePage(page: Page, name) {
+  const communicationPage = await ApplyPage.initialize(page, `Communication and language needs for ${name}`)
+
+  await communicationPage.checkRadioInGroup('additional communication needs', 'No')
+  await communicationPage.checkRadioInGroup('interpreter', 'No')
+  await communicationPage.checkRadioInGroup('need any support', 'No')
+
+  await communicationPage.clickSave()
+}
+
+async function completeLearningDifficultiesPage(page: Page, name) {
+  const learningPage = await ApplyPage.initialize(page, `Learning difficulties and neurodiversity for ${name}`)
+
+  await learningPage.checkRadioInGroup('additional needs', 'No')
+  await learningPage.checkRadioInGroup('vulnerable', 'No')
+  await learningPage.checkRadioInGroup('difficulties interacting', 'No')
+  await learningPage.checkRadioInGroup('additional support', 'No')
+
+  await learningPage.clickSave()
+}
+
+async function completeBrainInjuryPage(page: Page, name) {
+  const brainInjuryPage = await ApplyPage.initialize(page, `Brain injury needs for ${name}`)
+
+  await brainInjuryPage.checkRadioInGroup('brain injury?', 'No')
+  await brainInjuryPage.checkRadioInGroup('vulnerable', 'No')
+  await brainInjuryPage.checkRadioInGroup('difficulties interacting', 'No')
+  await brainInjuryPage.checkRadioInGroup('additional support', 'No')
+
+  await brainInjuryPage.clickSave()
+}
+
+async function completeOtherHealthPage(page: Page, name) {
+  const otherHealthPage = await ApplyPage.initialize(page, `Other health needs for ${name}`)
+
+  // we can't use the normal checkRadioInGroup() helper due to follow-on yes/no radios
+  // triggering Error: strict mode violation
+  await page.locator('css=input[name="hasLongTermHealthCondition"][value="no"]').click()
+
+  await otherHealthPage.checkRadioInGroup('seizures', 'No')
+  await otherHealthPage.checkRadioInGroup('treatment for cancer', 'No')
+
+  await otherHealthPage.clickSave()
+}

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -4,6 +4,7 @@ import {
   completeAboutThePersonSection,
   completeAreaAndFundingSection,
   completeBeforeYouStartSection,
+  completeRisksAndNeedsSection,
   enterCrn,
   startAnApplication,
 } from '../steps/apply'
@@ -14,5 +15,6 @@ test('create a CAS-2 application', async ({ page, person }) => {
   await completeBeforeYouStartSection(page, person.name)
   await completeAreaAndFundingSection(page, person.name)
   await completeAboutThePersonSection(page, person.name)
-  await expect(page.getByText('You have completed 3 of 4 sections')).toBeVisible()
+  await completeRisksAndNeedsSection(page, person.name)
+  await expect(page.getByText('You have completed 4 of 4 sections')).toBeVisible()
 })


### PR DESCRIPTION
## Add steps for "Health needs" task

We take the path of least resistance (mainly 'No' responses) as the complex answers are exercised in our integration tests in the UI repo.

We use fuzzy matches on labels where possible, for maximum resilence as copy will change. For example:

> "long term health conditions"

rather than

> "Are they managing any long term health conditions?"

There are 3 cases where we need to use a manual and less user-driven selector to avoid "Error: strict mode violation" situations. This is typically were we have nested Yes/No questions and the labels for both sets of options are the same (e.g. Yes/No). In those cases we use a CSS selector like:

```
locator('css=input[name="hasLongTermHealthCondition"][value="no"]')
```

In future we should aim to identify these scenarios when marking up the views and use Playwright's "Locate by test id" helper (see https://playwright.dev/docs/locators#locate-by-test-id) to allow something like:

```
page.getByTestId('hasLongTermHealthCondition').getByLabel('No')
```

That would be more robust.