### PR TITLE
Add local creds for e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,9 +36,9 @@ export default defineConfig<TestOptions>({
       use: {
         baseURL: 'http://localhost:3000',
         user: {
-          name: 'JIM SNOW',
-          username: 'jimsnowldap',
-          password: 'secret',
+          name: 'Pom User',
+          username: 'POM_USER',
+          password: 'password123456',
         },
       },
     },

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -16,5 +16,5 @@ test('create a CAS-2 application', async ({ page, person }) => {
   await completeAreaAndFundingSection(page, person.name)
   await completeAboutThePersonSection(page, person.name)
   await completeRisksAndNeedsSection(page, person.name)
-  await expect(page.getByText('You have completed 4 of 4 sections')).toBeVisible()
+  await expect(page.getByText('You have completed 4 of 5 sections')).toBeVisible()
 })


### PR DESCRIPTION
* add POM user
  * The CAS2 UI now requires a NOMIS user to login locally. These the ones
suggested [by AP Tools](https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/46)
* correct number of sections completed